### PR TITLE
Add TypeScript check step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Set the following environment variables:
 - Optional: `ISSUER_URL` to override the default OpenID issuer
 
 ## Development
-Install dependencies and run the dev server:
+Install dependencies, verify the TypeScript setup, and run the dev server:
 ```bash
 npm install
+npm run check
 npm run dev
 ```
 The backend runs on port 5000 and serves the React client via Vite middleware.


### PR DESCRIPTION
## Summary
- document running `npm run check` in the development section

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855046704748320ad1adf02cfd6c6c0