### PR TITLE
Add env var checks for Replit auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ WebSeoSage is a full‑stack SEO analysis platform. It combines an Express API w
 - Node.js 20+
 - PostgreSQL database
 
-Set the following environment variables:
+Set the following environment variables (all required unless noted):
 - `DATABASE_URL` – PostgreSQL connection string
-- `SESSION_SECRET` – session cookie secret
-- `REPLIT_DOMAINS` and `REPL_ID` – Replit authentication configuration
+- `SESSION_SECRET` – session cookie secret used for Express sessions
+- `REPLIT_DOMAINS` – comma‑separated allowed domains for Replit auth
+- `REPL_ID` – your Replit application ID
 - Optional: `ISSUER_URL` to override the default OpenID issuer
+
+The server will fail to start if `SESSION_SECRET`, `REPLIT_DOMAINS` or `REPL_ID` are not provided.
 
 ## Development
 Install dependencies and run the dev server:

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -11,6 +11,12 @@ import { storage } from "./storage";
 if (!process.env.REPLIT_DOMAINS) {
   throw new Error("Environment variable REPLIT_DOMAINS not provided");
 }
+if (!process.env.REPL_ID) {
+  throw new Error("Environment variable REPL_ID not provided");
+}
+if (!process.env.SESSION_SECRET) {
+  throw new Error("Environment variable SESSION_SECRET not provided");
+}
 
 const getOidcConfig = memoize(
   async () => {


### PR DESCRIPTION
## Summary
- validate `REPL_ID` and `SESSION_SECRET` in `server/replitAuth.ts`
- document required environment variables in README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: puppeteer Chrome download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855046349508320ac11caf460eea679