### PR TITLE
Add Puppeteer path env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Set the following environment variables:
 - `SESSION_SECRET` – session cookie secret
 - `REPLIT_DOMAINS` and `REPL_ID` – Replit authentication configuration
 - Optional: `ISSUER_URL` to override the default OpenID issuer
+- Optional: `PUPPETEER_EXECUTABLE_PATH` to specify the Chromium/Chrome binary used by Puppeteer
 
 ## Development
 Install dependencies and run the dev server:

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,11 +15,12 @@ class SeoAnalyzer {
   async analyzeWebsite(url: string) {
     let browser;
     try {
-      browser = await puppeteer.launch({ 
+      const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+      browser = await puppeteer.launch({
         headless: true,
-        executablePath: '/nix/store/zi4f80l169xlmivz8vja8wlphq74qqk0-chromium-125.0.6422.141/bin/chromium',
+        ...(executablePath ? { executablePath } : {}),
         args: [
-          '--no-sandbox', 
+          '--no-sandbox',
           '--disable-setuid-sandbox',
           '--disable-dev-shm-usage',
           '--disable-accelerated-2d-canvas',

--- a/server/serp-tracker.ts
+++ b/server/serp-tracker.ts
@@ -7,9 +7,10 @@ export class SerpTracker {
 
   async initBrowser() {
     if (!this.browser) {
+      const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
       this.browser = await puppeteer.launch({
         headless: true,
-        executablePath: '/nix/store/zi4f80l169xlmivz8vja8wlphq74qqk0-chromium-125.0.6422.141/bin/chromium',
+        ...(executablePath ? { executablePath } : {}),
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',


### PR DESCRIPTION
## Summary
- make Puppeteer executable path configurable via `PUPPETEER_EXECUTABLE_PATH`
- document the variable in the README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855045f97e483209b54a9c47499a847