### PR TITLE
Remove Puppeteer from SERP tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WebSeoSage is a full‑stack SEO analysis platform. It combines an Express API w
 ## Features
 - **Comprehensive SEO scans** with Puppeteer and Cheerio
 - **Backlink and keyword tracking** with historical score storage
-- **Real‑time SERP monitoring** and competitor gap analysis
+- **Real‑time SERP monitoring** with simulated rankings and competitor gap analysis
 - **User authentication** via Replit OpenID Connect
 - **Interactive dashboard** built with React, Radix UI and Tailwind CSS
 

--- a/replit.md
+++ b/replit.md
@@ -192,7 +192,7 @@ Changelog:
   - Professional competitor intelligence matching enterprise SEO tools standards
   - System successfully tested with three major competitors: Mental Health America, NAMI, SAMHSA
 - June 14, 2025. Real-time SERP position tracking system implemented:
-  - Built comprehensive SerpTracker class with Puppeteer automation for Google search position checking
+- Built comprehensive SerpTracker class with simulated Google search position checking
   - Added real-time rank tracking for individual keywords and bulk website tracking
   - Created RankTracker component with live position monitoring and historical trend charts
   - Integrated rank tracking tab into keywords dashboard with professional interface

--- a/server/serp-tracker.ts
+++ b/server/serp-tracker.ts
@@ -1,36 +1,7 @@
-import puppeteer, { Browser, Page } from 'puppeteer';
 import { storage } from './storage';
 import type { Keyword } from '@shared/schema';
 
 export class SerpTracker {
-  private browser: Browser | null = null;
-
-  async initBrowser() {
-    if (!this.browser) {
-      this.browser = await puppeteer.launch({
-        headless: true,
-        executablePath: '/nix/store/zi4f80l169xlmivz8vja8wlphq74qqk0-chromium-125.0.6422.141/bin/chromium',
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-accelerated-2d-canvas',
-          '--no-first-run',
-          '--no-zygote',
-          '--single-process',
-          '--disable-gpu'
-        ]
-      });
-    }
-    return this.browser;
-  }
-
-  async closeBrowser() {
-    if (this.browser) {
-      await this.browser.close();
-      this.browser = null;
-    }
-  }
 
   async checkKeywordPosition(keyword: string, targetDomain: string, location = 'global', device = 'desktop'): Promise<{
     position: number | null;
@@ -223,26 +194,7 @@ export class SerpTracker {
     }
   }
 
-  // Clean up resources
-  async cleanup() {
-    await this.closeBrowser();
-  }
 }
 
 // Export singleton instance
 export const serpTracker = new SerpTracker();
-
-// Cleanup on process exit
-process.on('exit', () => {
-  serpTracker.cleanup();
-});
-
-process.on('SIGINT', () => {
-  serpTracker.cleanup();
-  process.exit();
-});
-
-process.on('SIGTERM', () => {
-  serpTracker.cleanup();
-  process.exit();
-});


### PR DESCRIPTION
## Summary
- drop unused browser utilities from `SerpTracker`
- clarify that SERP tracking now uses simulated rankings

## Testing
- `npm run check` *(fails: ServerOptions type error)*

------
https://chatgpt.com/codex/tasks/task_e_6855045ba4848320865d49017a255efc